### PR TITLE
Ver. 2.90

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,7 +111,8 @@
         "GameTooltip",
         "GetContainerItemInfo",
         "GetContainerNumSlots",
-        "GetCursorPosition"
+        "GetCursorPosition",
+        "TooltipDataProcessor"
     ],
     "Lua.diagnostics.disable": [
         "redundant-parameter",

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 - UPDATE Dropdpwn Text Update Bugfix
 - UPDATE Temporary disabled the tooltip icons for Retail
 - FIX Healthmarker Option, custom raneg is disabeld if Auto range is enabled
+- FIX for Dropdown Macro Buttons
 ### Added
 - NEW Statusbar Texture K31
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,19 @@
 [Eng] - All changes to this project will be documented in this file. The latest changes are at the top.
 [Ger] - Alle Änderungen an diesem Projekt werden in dieser Datei dokumentiert. Die neuesten Änderungen stehen ganz oben.
 
+## [ver. 2.90] - 20.11.2022
+### Update
+- FIX mDock Talent Icon
+- FIX Teleports menu if no Profession is learned
+- FIX Datatext Systemmenu - fix menu entry for ElvUI options frame
+- FIX Tooltip Icons for Retail
+- FIX for !keys (post your M+ Key to Chat)
+- FIX Currencys Anima and Cataloged Research
+- ADD Evoker Interrupt Spell for Interrupt Check on Castbars
+- UPDATE removed Autographed Hearthstone Card from Teleports menu
+### Added
+- NEW Custom Class Colors (default is disabled)
+
 ## [ver. 2.89.1] - 16.11.2022
 ### Update
 - FIX Tooltips and Datatext

--- a/ElvUI_mMediaTag.toc
+++ b/ElvUI_mMediaTag.toc
@@ -1,7 +1,7 @@
 ## Interface: 100002
 ## Title: |cff1784d1ElvUI|r |CFF8E44ADm|r|CFF2ECC71Media|r|CFF3498DBTag|r
 ## Author: Blinkii
-## Version: 2.89.1
+## Version: 2.90
 ## Notes: ElvUI Plugin from Blinkii@Eu-Arygos | Support: mMediaTag@gmx.de
 ## RequiredDeps: ElvUI
 ## DefaultState: Enabled

--- a/ElvUI_mMediaTag_Classic.toc
+++ b/ElvUI_mMediaTag_Classic.toc
@@ -1,7 +1,7 @@
 ## Interface: 11403
 ## Title: |cff1784d1ElvUI|r |CFF8E44ADm|r|CFF2ECC71Media|r|CFF3498DBTag|r
 ## Author: Blinkii
-## Version: 2.89.1
+## Version: 2.90
 ## Notes: ElvUI Plugin from Blinkii@Eu-Arygos | Support: mMediaTag@gmx.de
 ## RequiredDeps: ElvUI
 ## DefaultState: Enabled

--- a/ElvUI_mMediaTag_Mainline.toc
+++ b/ElvUI_mMediaTag_Mainline.toc
@@ -1,7 +1,7 @@
 ## Interface: 100002
 ## Title: |cff1784d1ElvUI|r |CFF8E44ADm|r|CFF2ECC71Media|r|CFF3498DBTag|r
 ## Author: Blinkii
-## Version: 2.89.1
+## Version: 2.90
 ## Notes: ElvUI Plugin from Blinkii@Eu-Arygos | Support: mMediaTag@gmx.de
 ## RequiredDeps: ElvUI
 ## DefaultState: Enabled

--- a/ElvUI_mMediaTag_Wrath.toc
+++ b/ElvUI_mMediaTag_Wrath.toc
@@ -1,7 +1,7 @@
 ## Interface: 30400
 ## Title: |cff1784d1ElvUI|r |CFF8E44ADm|r|CFF2ECC71Media|r|CFF3498DBTag|r
 ## Author: Blinkii
-## Version: 2.89.1
+## Version: 2.90
 ## Notes: ElvUI Plugin from Blinkii@Eu-Arygos | Support: mMediaTag@gmx.de
 ## RequiredDeps: ElvUI
 ## DefaultState: Enabled

--- a/core/init.lua
+++ b/core/init.lua
@@ -33,6 +33,29 @@ end
 
 -- addon laden
 function mMT:Initialize()
+	if E.db[mPlugin].mCustomClassColors.enable then
+		mMT:SetCustomColors()
+
+		function E:ClassColor(class, usePriestColor)
+			if not class then return end
+		
+			local color = (E.db[mPlugin].mCustomClassColors.colors and E.db[mPlugin].mCustomClassColors.colors[class]) or (_G.CUSTOM_CLASS_COLORS and _G.CUSTOM_CLASS_COLORS[class]) or _G.RAID_CLASS_COLORS[class]
+			if type(color) ~= 'table' then return end
+		
+			if not color.colorStr then
+				color.colorStr = E:RGBToHex(color.r, color.g, color.b, 'ff')
+			elseif strlen(color.colorStr) == 6 then
+				color.colorStr = 'ff'..color.colorStr
+			end
+		
+			if usePriestColor and class == 'PRIEST' and tonumber(color.colorStr, 16) > tonumber(E.PriestColors.colorStr, 16) then
+				return E.PriestColors
+			else
+				return color
+			end
+		end
+	end
+
 	mMT:mMisc() -- module laden
 
 	if E.Retail then

--- a/core/mChangelog.lua
+++ b/core/mChangelog.lua
@@ -9,7 +9,7 @@ local format = format
 
 --Variables
 local ChangelogText =
-	"#### [ver. 2.89.1] - 16.11.2022\n\n### Update\n- |CFFFE7B2CFIX|r Tooltips and Datatext\n- |CFF58D68DUPDATE|r Dropdpwn Text Update Bugfix\n- |CFF58D68DUPDATE|r Temporary disabled the tooltip icons for Retail\n\n### Added\n- |CFF3498DBNEW|r Statusbar Texture K31"
+	"## [ver. 2.90] - 20.11.2022\n\n\n### Update\n\n- |CFFFE7B2CFIX|r mDock Talent Icon\n- |CFFFE7B2CFIX|r Teleports menu if no Profession is learned\n- |CFFFE7B2CFIX|r Datatext Systemmenu - fix menu entry for ElvUI options frame\n- |CFFFE7B2CFIX|r Tooltip Icons for Retail\n- |CFFFE7B2CFIX|r for !keys (post your M+ Key to Chat)\n- |CFFFE7B2CFIX|r Currencys Anima and Cataloged Research\n- |CFF58D68DADD|r Evoker Interrupt Spell for Interrupt Check on Castbars\n- |CFF58D68DUPDATE|r removed Autographed Hearthstone Card from Teleports menu\n\n### Added\n\n- |CFF3498DBNEW|r Custom Class Colors (default is disabled)"
 
 function mMT:Changelog(opt)
 	local Frame = CreateFrame("Frame", "mMediaTagChangelog", E.UIParent, "BackdropTemplate")

--- a/core/mChangelog.lua
+++ b/core/mChangelog.lua
@@ -53,7 +53,7 @@ function mMT:Changelog(opt)
 		Frame:Hide()
 
 		if opt then
-			E:ToggleOptionsUI()
+			E:ToggleOptions()
 		end
 	end)
 
@@ -65,6 +65,6 @@ function mMT:Changelog(opt)
 	mSkin:HandleButton(Close)
 
 	if opt then
-		E:ToggleOptionsUI()
+		E:ToggleOptions()
 	end
 end

--- a/core/mDropdown.lua
+++ b/core/mDropdown.lua
@@ -82,8 +82,8 @@ function mMT:mDropDown(list, frame, menuparent, ButtonWidth, HideDelay)
 		if not frame.buttons[i] then
 			if list[i].macro then
 				frame.buttons[i] = CreateFrame("Button", "MacroButton", frame, "SecureActionButtonTemplate")
-				frame.buttons[i]:SetAttribute("type*", "macro")
-				--frame.buttons[i]:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+				frame.buttons[i]:SetAttribute("type", "macro")
+				frame.buttons[i]:RegisterForClicks("LeftButtonUp", "LeftButtonDown")
 				frame.buttons[i]:SetAttribute("macrotext1", list[i].macro)
 			else
 				frame.buttons[i] = CreateFrame("Button", nil, frame)

--- a/core/mFunctions.lua
+++ b/core/mFunctions.lua
@@ -40,7 +40,7 @@ function mMT:mMisc()
 		mMT:mNamePlateBorderColor()
 	end
 
-	if E.db[mPlugin].mTIcon and not E.Retail then
+	if E.db[mPlugin].mTIcon then
 		mMT:TipIconSetup()
 	end
 

--- a/core/mOptions.lua
+++ b/core/mOptions.lua
@@ -395,6 +395,13 @@ local function OptionsCore()
 						childGroups = "tab",
 						args = {},
 					},
+					customclasscolors = {
+						order = 6,
+						type = "group",
+						name = L["Custom Class colors"],
+						childGroups = "tab",
+						args = {},
+					},
 				},
 			},
 			about = {
@@ -844,6 +851,13 @@ local function OptionsCoreClassic()
 						order = 4,
 						type = "group",
 						name = L["Custom Backdrop Textures"],
+						childGroups = "tab",
+						args = {},
+					},
+					customclasscolors = {
+						order = 5,
+						type = "group",
+						name = L["Custom Class colors"],
 						childGroups = "tab",
 						args = {},
 					},

--- a/core/mSettings.lua
+++ b/core/mSettings.lua
@@ -432,5 +432,23 @@ P[mPlugin] = {
 		["power"] = {["enable"] = false, ["texture"] = "mMediaTag M1"},
 		["castbar"] = {["enable"] = false, ["texture"] = "mMediaTag P4"}
 	},
-	["mCustomCombatIcons"] = 1
+	["mCustomCombatIcons"] = 1,
+	["mCustomClassColors"] = {
+		["enable"] = false, ["emediaenable"] = false,
+		["colors"] = {
+			["HUNTER"] = {["r"] = 0.67, ["g"] = 0.83, ["b"] = 0.45},
+			["WARLOCK"] = {["r"]  = 0.53,["g"]  = 0.53,["b"]  = 0.93},
+			["PRIEST"] = {["r"]  = 1.00,["g"]  = 1.00,["b"]  = 1.00},
+			["PALADIN"] = {["r"] = 0.96,["g"]  = 0.55,["b"]  = 0.73},
+			["MAGE"] = {["r"] = 0.20, ["g"] = 0.78, ["b"] = 0.92},
+			["ROGUE"] = {["r"]  = 1.00,["g"]  = 0.96,["b"]  = 0.41},
+			["DRUID"] = {["r"] = 1.00, ["g"] = 0.49, ["b"] = 0.04},
+			["SHAMAN"] = {["r"]  = 0.00,["g"]  = 0.44,["b"]  = 0.87},
+			["WARRIOR"] = {["r"]  = 0.78,["g"]  = 0.61,["b"]  = 0.43},
+			["DEATHKNIGHT"] = {["r"] = 0.77, ["g"] = 0.12, ["b"] = 0.23},
+			["MONK"] = {["r"] = 0.00, ["g"] = 1.00, ["b"] = 0.60},
+			["DEMONHUNTER"] = {["r"] = 0.64, ["g"] = 0.19, ["b"] = 0.79},
+			["EVOKER"] = {["r"] = 0.20, ["g"] = 0.58, ["b"] = 0.50},
+		}
+	},
 }

--- a/misc/CurrencyShadowlands/mAnima.lua
+++ b/misc/CurrencyShadowlands/mAnima.lua
@@ -36,11 +36,12 @@ local function mBagCheck()
 	for bagID = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
 		local slots = GetContainerNumSlots(bagID)
 		for slot = 1, slots do
-			local itemID = select(10, GetContainerItemInfo(bagID, slot))
-			local itemCount = select(2, GetContainerItemInfo(bagID, slot))
-			local _, spellID = GetItemSpell(itemID)
-			if spellID and Animas[spellID] then
-				mAmount = mAmount + (Animas[spellID] * itemCount)
+			local containerInfo = GetContainerItemInfo(bagID, slot)
+			if containerInfo then
+				local _, spellID = GetItemSpell(containerInfo.itemID)
+				if spellID and Animas[spellID] then
+					mAmount = mAmount + (Animas[spellID] * containerInfo.stackCount)
+				end
 			end
 		end
 	end

--- a/misc/CurrencyShadowlands/mCatalogedResearch.lua
+++ b/misc/CurrencyShadowlands/mCatalogedResearch.lua
@@ -11,11 +11,7 @@ local strjoin = strjoin
 
 --WoW API / Variables
 local _G = _G
-local GetContainerNumSlots = C_Container.GetContainerNumSlots
-local GetContainerItemInfo = C_Container.GetContainerItemInfo
-local GetItemSpell = GetItemSpell
 local C_CurrencyInfo = C_CurrencyInfo
-local IsAddOnLoaded = IsAddOnLoaded
 
 --Variables
 local displayString, lastPanel = "", nil
@@ -24,9 +20,7 @@ local mTextName = "mCatalogedResearch"
 local mCurrencyID = 1931
 local hideCurrency = false
 
-local function mBagCheck()
-	local mAmount = 0
-	local mResearch = {
+local mResearch = {
 		[186685] = 1,
 		[187322] = 8,
 		[187457] = 8,
@@ -56,7 +50,10 @@ local function mBagCheck()
 		[187350] = 300,
 		[187335] = 300,
 	}
+
+local function mBagCheck()
 	local mAmount = 0
+
 	for itemID, mValue in pairs(mResearch) do
 		local mCount = GetItemCount(itemID, true)
 		mAmount = mAmount + mCount * mValue

--- a/misc/Dock/mFPSMS.lua
+++ b/misc/Dock/mFPSMS.lua
@@ -169,7 +169,7 @@ local function OnClick(self, button)
 				HideUIPanel(GameMenuFrame)
 			end
 		else
-			E:ToggleOptionsUI()
+			E:ToggleOptions()
 		end
 	end
 end

--- a/misc/Dock/mMainMenu.lua
+++ b/misc/Dock/mMainMenu.lua
@@ -216,7 +216,7 @@ local function OnClick(self, button)
 			mMT:MuteVolume()
 		else
 			mMT:mOnClick(self, "CheckFrameMainMenu")
-			E:ToggleOptionsUI()
+			E:ToggleOptions()
 		end
 	end
 end

--- a/misc/Dock/mTalent.lua
+++ b/misc/Dock/mTalent.lua
@@ -190,23 +190,26 @@ local function OnClick(self, button)
 		end
 
 		if button == "LeftButton" then
-			if not _G.PlayerTalentFrame then
-				_G.LoadAddOn("Blizzard_TalentUI")
+			local frame = _G.ClassTalentFrame
+			if not frame then
+				LoadAddOn('Blizzard_ClassTalentUI')
+				frame = _G.ClassTalentFrame
 			end
-			if not _G.PlayerTalentFrame:IsShown() then
-				ShowUIPanel(_G.PlayerTalentFrame)
+
+			if frame:IsShown() then
+				HideUIPanel(frame)
 			else
-				HideUIPanel(_G.PlayerTalentFrame)
+				ShowUIPanel(frame)
 			end
 		elseif button == "MiddleButton" then
-			DT:SetEasyMenuAnchor(DT.EasyMenu, self)
-			_G.EasyMenu(specList, DT.EasyMenu, nil, nil, nil, "MENU")
+			E:SetEasyMenuAnchor(E.EasyMenu, self)
+			_G.EasyMenu(specList, E.EasyMenu, nil, nil, nil, "MENU")
 		else
 			local _, specName = GetSpecializationInfo(specIndex)
 			menuList[2].text = format(LOOT_SPECIALIZATION_DEFAULT, specName)
 
-			DT:SetEasyMenuAnchor(DT.EasyMenu, self)
-			_G.EasyMenu(menuList, DT.EasyMenu, nil, nil, nil, "MENU")
+			E:SetEasyMenuAnchor(E.EasyMenu, self)
+			_G.EasyMenu(menuList, E.EasyMenu, nil, nil, nil, "MENU")
 		end
 	end
 end

--- a/misc/load_misc.xml
+++ b/misc/load_misc.xml
@@ -18,7 +18,7 @@
 	<Script file="mProfessionMenu.lua"/>
 	<Script file="mSystemMenu.lua"/>
 	<Script file="mTags.lua"/>
-	<!-- <Script file="mTipIcon.lua"/> -->
+	<Script file="mTipIcon.lua"/>
 	<Script file="mTools.lua"/>
 	<Script file="mVolumeDisplay.lua"/>
 	<Script file="mRoleIcons.lua"/>

--- a/misc/load_misc.xml
+++ b/misc/load_misc.xml
@@ -5,6 +5,7 @@
 	<Script file="mCombatTime.lua"/>
 	<Script file="mCoordinatesX.lua"/>
 	<Script file="mCoordinatesY.lua"/>
+	<Script file="mCustomClassColors.lua"/>
 	<Script file="mBGTexture.lua"/>
 	<Script file="mCastbar.lua"/>
 	<Script file="mCombatIcon.lua"/>

--- a/misc/load_misc_classic.xml
+++ b/misc/load_misc_classic.xml
@@ -5,6 +5,7 @@
 	<Script file="mCombatTime.lua"/>
 	<Script file="mCoordinatesX.lua"/>
 	<Script file="mCoordinatesY.lua"/>
+	<Script file="mCustomClassColors.lua"/>
 	<Script file="mFunctionsMisc.lua"/>
 	<Script file="mSystemMenu.lua"/>
 	<Script file="mTags.lua"/>

--- a/misc/mCastbar.lua
+++ b/misc/mCastbar.lua
@@ -66,6 +66,9 @@ local interruptSpellList = {
 	--DEMONHUNTER
 	[577] = 183752,
 	[581] = 183752,
+	--EVOKER
+	[1467] = 351338,
+	[1468] = 351338,
 }
 
 function mMT:mUpdateKick()

--- a/misc/mCustomClassColors.lua
+++ b/misc/mCustomClassColors.lua
@@ -1,0 +1,325 @@
+local E, L, V, P, G = unpack(ElvUI)
+local mPlugin = "mMediaTag"
+local mMT = E:GetModule(mPlugin)
+local addon, ns = ...
+local ClassColor = E.oUF.colors.class
+local UF = E:GetModule('UnitFrames')
+
+local mInsert = table.insert
+local classes = {"HUNTER", "WARLOCK", "PRIEST", "PALADIN", "MAGE", "ROGUE", "DRUID", "SHAMAN", "WARRIOR", "DEATHKNIGHT", "MONK", "DEMONHUNTER", "EVOKER"}
+
+local function UpdateColors()
+    for i, className in ipairs(classes) do
+		E.oUF.colors.class[className][1] = E.db[mPlugin].mCustomClassColors.colors[className]["r"]
+        E.oUF.colors.class[className][2] = E.db[mPlugin].mCustomClassColors.colors[className]["g"]
+        E.oUF.colors.class[className][3] = E.db[mPlugin].mCustomClassColors.colors[className]["b"]
+        E.oUF.colors.class[className]["r"] = E.db[mPlugin].mCustomClassColors.colors[className]["r"]
+        E.oUF.colors.class[className]["g"] = E.db[mPlugin].mCustomClassColors.colors[className]["g"]
+        E.oUF.colors.class[className]["b"] = E.db[mPlugin].mCustomClassColors.colors[className]["b"]
+	end
+	UF:Update_AllFrames()
+end
+
+
+local function ResetColors()
+	for i, className in ipairs(classes) do
+		local color = RAID_CLASS_COLORS[className]
+		E.db[mPlugin].mCustomClassColors.colors[className]["r"] = RAID_CLASS_COLORS[className]["r"]
+        E.db[mPlugin].mCustomClassColors.colors[className]["g"] = RAID_CLASS_COLORS[className]["g"]
+        E.db[mPlugin].mCustomClassColors.colors[className]["b"] = RAID_CLASS_COLORS[className]["b"]
+		E.oUF.colors.class[className][1] = E.db[mPlugin].mCustomClassColors.colors[className]["r"]
+        E.oUF.colors.class[className][2] = E.db[mPlugin].mCustomClassColors.colors[className]["g"]
+        E.oUF.colors.class[className][3] = E.db[mPlugin].mCustomClassColors.colors[className]["b"]
+        E.oUF.colors.class[className]["r"] = E.db[mPlugin].mCustomClassColors.colors[className]["r"]
+        E.oUF.colors.class[className]["g"] = E.db[mPlugin].mCustomClassColors.colors[className]["g"]
+        E.oUF.colors.class[className]["b"] = E.db[mPlugin].mCustomClassColors.colors[className]["b"]
+	end
+	UF:Update_AllFrames()
+end
+
+local function SetElvUIMediaColor()
+	local _, unitClass = UnitClass("PLAYER")
+	local colorDB = E.db[mPlugin].mCustomClassColors.colors[unitClass]
+	E.db.general.valuecolor["r"] = colorDB.r
+	E.db.general.valuecolor["g"] = colorDB.g
+	E.db.general.valuecolor["b"] = colorDB.b
+	E.db.general.valuecolor["a"] = 1
+end
+
+function mMT:SetCustomColors()
+	UpdateColors()
+	if E.db[mPlugin].mCustomClassColors.emediaenable then
+		SetElvUIMediaColor()
+	end
+end
+
+local function customclasscolorsOptions()
+	E.Options.args.mMediaTag.args.cosmetic.args.customclasscolors.args = {
+		colorsheader = {
+			order = 1,
+			type = "header",
+			name = L["Custom Class colors"]
+		},
+		customcolors = {
+			order = 2,
+			type = "toggle",
+			name = L["Custom Class colors"],
+			desc = L["Enable Custom Class colors."],
+			get = function(info)
+				return E.db[mPlugin].mCustomClassColors.enable
+			end,
+			set = function(info, value)
+				E.db[mPlugin].mCustomClassColors.enable = value
+				E:StaticPopup_Show('CONFIG_RL')
+			end
+		},
+		emediacolor = {
+			order = 3,
+			type = "toggle",
+			name = L["Change ElvUI Media color"],
+			disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				return E.db[mPlugin].mCustomClassColors.emediaenable
+			end,
+			set = function(info, value)
+				E.db[mPlugin].mCustomClassColors.emediaenable = value
+				SetElvUIMediaColor()
+				E:StaticPopup_Show('CONFIG_RL')
+			end
+		},
+		updatecolors = {
+			order = 4,
+			type = "execute",
+			name = L["Set Custom colors"],
+			disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			func = function()
+				UpdateColors()
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+		resetcolors = {
+			order = 5,
+			type = "execute",
+			name = L["Reset Custom colors"],
+			func = function()
+				ResetColors()
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        classheader = {
+			order = 10,
+			type = "header",
+			name = L["Class colors"]
+		},
+        HUNTER = {
+			type = "color",
+			order = 11,
+			name = L["HUNTER"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.HUNTER
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.HUNTER
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        WARLOCK = {
+			type = "color",
+			order = 12,
+			name = L["WARLOCK"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.WARLOCK
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.WARLOCK
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        PRIEST = {
+			type = "color",
+			order = 13,
+			name = L["PRIEST"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.PRIEST
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.PRIEST
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        PALADIN = {
+			type = "color",
+			order = 14,
+			name = L["PALADIN"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.PALADIN
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.PALADIN
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        MAGE = {
+			type = "color",
+			order = 15,
+			name = L["MAGE"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.MAGE
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.MAGE
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        ROGUE = {
+			type = "color",
+			order = 16,
+			name = L["ROGUE"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.ROGUE
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.ROGUE
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        DRUID = {
+			type = "color",
+			order = 17,
+			name = L["DRUID"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DRUID
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DRUID
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        SHAMAN = {
+			type = "color",
+			order = 18,
+			name = L["SHAMAN"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.SHAMAN
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.SHAMAN
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        WARRIOR = {
+			type = "color",
+			order = 19,
+			name = L["WARRIOR"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.WARRIOR
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.WARRIOR
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        DEATHKNIGHT = {
+			type = "color",
+			order = 20,
+			name = L["DEATHKNIGHT"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DEATHKNIGHT
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DEATHKNIGHT
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        MONK = {
+			type = "color",
+			order = 21,
+			name = L["MONK"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.MONK
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.MONK
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        DEMONHUNTER = {
+			type = "color",
+			order = 22,
+			name = L["DEMONHUNTER"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DEMONHUNTER
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.DEMONHUNTER
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+        EVOKER = {
+			type = "color",
+			order = 23,
+			name = L["EVOKER"],
+			hasAlpha = false,
+            disabled = function() return not E.db[mPlugin].mCustomClassColors.enable end,
+			get = function(info)
+				local t = E.db[mPlugin].mCustomClassColors.colors.EVOKER
+				return t.r, t.g, t.b
+			end,
+			set = function(info, r, g, b)
+				local t = E.db[mPlugin].mCustomClassColors.colors.EVOKER
+				t.r, t.g, t.b = r, g, b
+				E:StaticPopup_Show('CONFIG_RL')
+			end,
+		},
+	}
+end
+
+mInsert(ns.Config, customclasscolorsOptions)

--- a/misc/mKeystoneToChat.lua
+++ b/misc/mKeystoneToChat.lua
@@ -29,15 +29,17 @@ local function mCheckText(text)
 	end
 end
 
-local function mGetKey()
+local function mGetKeyLink()
 	local mKeys = {}
 	for bag = 0, NUM_BAG_SLOTS do
 		local bSlots = GetContainerNumSlots(bag)
 		for slot = 1, bSlots do
-			local itemLink, _, _, itemID = select(7, GetContainerItemInfo(bag, slot))
-			-- 180653 = SL/ 187786 = Legion
-			if itemID == 180653 or itemID == 187786 then
-				mKeys[itemID] = itemLink
+			local containerInfo = GetContainerItemInfo(bag, slot)
+			if containerInfo then
+				-- 180653 = SL/ 187786 = Legion
+				if containerInfo.itemID == 180653 or containerInfo.itemID == 187786 then
+					mKeys[containerInfo.itemID] = containerInfo.hyperlink
+				end
 			end
 		end
 	end
@@ -57,7 +59,7 @@ local function OnEvent(self, event, ...)
 				channel = "RAID"
 			end
 
-			local myKeys = mGetKey()
+			local myKeys = mGetKeyLink()
 			if myKeys then
 				local link = nil
 				-- 180653 = SL/ 187786 = Legion
@@ -68,6 +70,7 @@ local function OnEvent(self, event, ...)
 				else
 					link = myKeys[187786]
 				end
+
 				if link and channel then
 					SendChatMessage(link, channel)
 				end

--- a/misc/mSystemMenu.lua
+++ b/misc/mSystemMenu.lua
@@ -221,7 +221,7 @@ local function OnClick(self, button)
 							_G.UIErrorsFrame:AddMessage(E.InfoColor .. _G.ERR_NOT_IN_COMBAT)
 							return
 						end
-						E:ToggleOptionsUI()
+						E:ToggleOptions()
 					end,
 				},
 
@@ -349,7 +349,7 @@ local function OnClick(self, button)
 							_G.UIErrorsFrame:AddMessage(E.InfoColor .. _G.ERR_NOT_IN_COMBAT)
 							return
 						end
-						E:ToggleOptionsUI()
+						E:ToggleOptions()
 					end,
 				},
 

--- a/misc/mTeleports.lua
+++ b/misc/mTeleports.lua
@@ -341,8 +341,13 @@ end
 
 local function EngineeringCheck()
 	local prof1, prof2 = GetProfessions()
-	prof1 = select(7, GetProfessionInfo(prof1))
-	prof2 = select(7, GetProfessionInfo(prof2))
+	if prof1 then
+		prof1 = select(7, GetProfessionInfo(prof1))
+	end
+	
+	if prof2 then
+		prof2 = select(7, GetProfessionInfo(prof2))
+	end
 
 	return prof1 == 202 or prof2 == 202
 end

--- a/misc/mTeleports.lua
+++ b/misc/mTeleports.lua
@@ -57,7 +57,6 @@ local Teleports = {
 		165669, --lunar-elders-hearthstone
 		166747, --brewfest-revelers-hearthstone
 		165802, --noble-gardeners-hearthstone
-		118427, --autographed-hearthstone-card
 		190196, --enlightened-hearthstone
 	},
 	engineering = {

--- a/misc/mTipIcon.lua
+++ b/misc/mTipIcon.lua
@@ -8,6 +8,26 @@ local _G = _G
 local GetItemIcon = GetItemIcon
 local GetSpellInfo = GetSpellInfo
 
+local function AddToolTipIconItem(tooltip, data)
+	if data  then
+		if data.id and tooltip:GetName() then
+			local title = _G[tooltip:GetName() .. "TextLeft1"]
+			local icon = GetItemIcon(data.id)
+			title:SetFormattedText("|T%s:%d|t %s", icon, E.db[mPlugin].mTIconSize, title:GetText())
+		end
+	end
+end
+
+local function AddToolTipIconSpell(tooltip, data)
+	if data  then
+		if data.id and tooltip:GetName() then
+			local title = _G[tooltip:GetName() .. "TextLeft1"]
+			local icon = GetSpellTexture(data.id)
+			title:SetFormattedText("|T%s:%d|t %s", icon, E.db[mPlugin].mTIconSize, title:GetText())
+		end
+	end
+end
+
 local function AddTooltipIcon(self, icon)
 	if icon then
 		local title = _G[self:GetName() .. "TextLeft1"]
@@ -19,9 +39,7 @@ local function AddTooltipIcon(self, icon)
 end
 
 local function hookTip(tip)
-	if tip and E.Retail then
-		--TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, OnTooltipSetItem)
-	else
+	if tip and not E.Retail then
 		tip:HookScript("OnTooltipSetItem", function(self, ...)
 			local _, link = self:GetItem()
 			local icon = link and GetItemIcon(link)
@@ -39,9 +57,14 @@ local function hookTip(tip)
 end
 
 function mMT:TipIconSetup()
-	hookTip(_G["GameTooltip"])
-	hookTip(_G["ItemRefTooltip"])
-	hookTip(_G["ShoppingTooltip1"])
-	hookTip(_G["ShoppingTooltip2"])
-	hookTip(_G["ShoppingTooltip3"])
+	if E.Retail then
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, AddToolTipIconItem)
+		TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Spell, AddToolTipIconSpell)
+	else
+		hookTip(_G["GameTooltip"])
+		hookTip(_G["ItemRefTooltip"])
+		hookTip(_G["ShoppingTooltip1"])
+		hookTip(_G["ShoppingTooltip2"])
+		hookTip(_G["ShoppingTooltip3"])
+	end
 end

--- a/misc/mTipIcon.lua
+++ b/misc/mTipIcon.lua
@@ -19,7 +19,9 @@ local function AddTooltipIcon(self, icon)
 end
 
 local function hookTip(tip)
-	if tip then
+	if tip and E.Retail then
+		--TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, OnTooltipSetItem)
+	else
 		tip:HookScript("OnTooltipSetItem", function(self, ...)
 			local _, link = self:GetItem()
 			local icon = link and GetItemIcon(link)


### PR DESCRIPTION
## [ver. 2.90] - 20.11.2022
### Update
- FIX mDock Talent Icon
- FIX Teleports menu if no Profession is learned
- FIX Datatext Systemmenu - fix menu entry for ElvUI options frame
- FIX Tooltip Icons for Retail
- FIX for !keys (post your M+ Key to Chat)
- FIX Currencys Anima and Cataloged Research
- ADD Evoker Interrupt Spell for Interrupt Check on Castbars
- UPDATE removed Autographed Hearthstone Card from Teleports menu
### Added
- NEW Custom Class Colors (default is disabled)