### PR TITLE
Ver. 3.22

### DIFF
--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Classic.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Classic.toc
@@ -1,6 +1,6 @@
 ## Interface: 11404
 ## Author: Blinkii
-## Version: 3.21
+## Version: 3.22
 ## Title: |cff1784d1ElvUI|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: mMediaTag & Tools is a plugin for ElvUI. mMediaTag adds many media files like textures/ fonts/ icons and some tools to ElvUI.
 ## Notes-deDE: mMediaTag & Tools ist ein Plugin für ElvUI. mMediaTag fügt viele Mediendateien wie Texturen/ Schriften/ Symbole und einige Tools zu ElvUI hinzu.

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
@@ -1,6 +1,6 @@
 ## Interface: 100107
 ## Author: Blinkii
-## Version: 3.21
+## Version: 3.22
 ## Title: |cff1784d1ElvUI|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: ElvUI Plugin from Blinkii | Support: mMediaTag@gmx.de
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Wrath.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Wrath.toc
@@ -1,6 +1,6 @@
 ## Interface: 30403
 ## Author: Blinkii
-## Version: 3.21
+## Version: 3.22
 ## Title: |cff1784d1ElvUI|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: ElvUI Plugin from Blinkii | Support: mMediaTag@gmx.de
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon

--- a/Addon/ElvUI_mMediaTag/core/options/changelog.lua
+++ b/Addon/ElvUI_mMediaTag/core/options/changelog.lua
@@ -38,7 +38,11 @@ local change_log_fix = {
 	"Portraits Event updates to prevent wrong or empty Portraits",
 	"Nil error for custom Class colors",
 	"Nil error on custom Phase icon",
-	"Updates now correctly for Profession Datatext"
+	"Updates now correctly for Profession Datatext",
+	"AFK Screen for Classic Versions",
+	"Guild Dock, is not Updating correctly",
+	"Remove DEV tag",
+	"MediaPack Toc files"
 }
 
 local function Concatenation(tbl, icon, color)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 # Changelog - ElvUI_mMediaTag
 [Eng] - All changes to this project will be documented in this file. The latest changes are at the top.
 
-## [ver. 3.22] - 12.10.2023
+## [ver. 3.22] - 13.10.2023
 ### FIX
 - FIX - AFK Screen for Classic Versions
 - FIX - Guild Dock, is not Updating correctly
@@ -33,7 +33,6 @@
 - NEW - Datatext Durability and Ilevel in one
 - NEW - Chat backgrounds 7 - 13
 - NEW - Textures, mMT Blank and mMT Target
--
 
 ## [ver. 3.20] - 20.09.2023
 ### FIX

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 # Changelog - ElvUI_mMediaTag
 [Eng] - All changes to this project will be documented in this file. The latest changes are at the top.
 
-## [ver. 3.21] - 12.10.2023
+## [ver. 3.22] - 12.10.2023
 ### FIX
 - FIX - AFK Screen for Classic Versions
 - FIX - Guild Dock, is not Updating correctly


### PR DESCRIPTION
## [ver. 3.22] - 13.10.2023
### FIX
- FIX - AFK Screen for Classic Versions
- FIX - Guild Dock, is not Updating correctly
- FIX - Remove DEV tag
- FIX - MediaPack Toc files
### Update
- UPDATE - Update Boss Portrait event

## [ver. 3.21] - 12.10.2023
### FIX
- FIX - Portraits Event updates to prevent wrong or empty Portraits
- FIX - Nil error for custom Class colors
- FIX - Nil error on custom Phase icon
- FIX - Updates now correctly for Profession Datatext
### Update
- UPDATE - Changed Tag mTargetAbbrev to mTarget:abbrev and also add short Versions
- UPDATE - Example Docks, and add ne examples XIV like, custom Dock, micro menu replacement
- UPDATE - Font flags for ElvUI shadow flag
- UPDATE - Removed golden-hearthstone-card-lord-jaraxxus from Teleports Datatext, thx Xheno
- UPDATE - Removed Statusbar textures q5 and q6, dont liked them
### NEW
- NEW - Tags mHealth:noStatus, mHealth:noStatus:current-percent, mHealth:noStatus, mPower:percent:hideZero
- NEW - Font Montserrat
- NEW - Icons for Tags, role and Classification
- NEW - Icons fr Role
- NEW - Castbar background color for Castbar modules
- NEW - Slider for Portrait offsets/ zoom
- NEW - Datatext for first and second Profession
- NEW - Datatext Durability and Ilevel in one
- NEW - Chat backgrounds 7 - 13
- NEW - Textures, mMT Blank and mMT Target