### PR TITLE
Ver. 3.30

### DIFF
--- a/Addon/ElvUI_mMediaTag/core/core.lua
+++ b/Addon/ElvUI_mMediaTag/core/core.lua
@@ -56,7 +56,6 @@ function mMT:JiberishIcons()
 		if jib_tbl.version then
 			local major, minor, patch  = strsplit(".", jib_tbl.version, 3)
 			jib_tbl.old = tonumber(major) <= 1 and tonumber(minor) == 0 and tonumber(patch) <= 3
-			mMT:Print(jib_tbl.version, major, minor, patch, jib_tbl.old)
 		end
 
 		if jib_tbl.old then


### PR DESCRIPTION
## [ver. 3.30] - 25.03.2024
### FIX
- FIX - Dropdown menu Button height, depends now on Font size to prevent overlapping text
- FIX - misalignment of the non-player Portraits when Classicons is enabled
### Update
- UPDATE - Add Tooltip Anchor settings for Teleports Datatext
- UPDATE - TOC update for Classic and Retail
### NEW
- NEW - Add support for the great Class Icons from Jiberish for Portraits
- NEW - TAG mTargetMarker