### PR TITLE
Ver. 3.31

### DIFF
--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Classic.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Classic.toc
@@ -1,6 +1,6 @@
 ## Interface: 11501
 ## Author: Blinkii
-## Version: 3.30
+## Version: 3.31
 ## Title: |CFF6559F1m|r|CFFA037E9M|r|CFFDD14E0T|r - |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: mMediaTag & Tools is a plugin for ElvUI. mMediaTag adds many media files like textures/ fonts/ icons and some tools to ElvUI.
 ## Notes-deDE: mMediaTag & Tools ist ein Plugin für ElvUI. mMediaTag fügt viele Mediendateien wie Texturen/ Schriften/ Symbole und einige Tools zu ElvUI hinzu.

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
@@ -1,6 +1,6 @@
 ## Interface: 100206
 ## Author: Blinkii
-## Version: 3.30
+## Version: 3.31
 ## Title: |CFF6559F1m|r|CFFA037E9M|r|CFFDD14E0T|r - |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: ElvUI Plugin from Blinkii | Support: mMediaTag@gmx.de
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Wrath.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Wrath.toc
@@ -1,6 +1,6 @@
 ## Interface: 30403
 ## Author: Blinkii
-## Version: 3.30
+## Version: 3.31
 ## Title: |CFF6559F1m|r|CFFA037E9M|r|CFFDD14E0T|r - |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon
 ## AddonCompartmentFunc: ElvUI_mMediaTag_OnAddonCompartmentClick

--- a/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
+++ b/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
@@ -148,16 +148,19 @@ local textures = {
 }
 
 local function mirrorTexture(texture, mirror)
-	--if not E.db.mMT.portraits.general.classicons then
+	if texture.mClass then
+		local left, right, top, bottom = unpack(texture.mCoords)
+		texture:SetTexCoord(mirror and right or left, mirror and left or right, top, bottom)
+	else
 		texture:SetTexCoord(mirror and 1 or 0, mirror and 0 or 1, 0, 1)
---	end
+	end
 end
 
 local function SetPortraits(portrait, unit, masking, mirror)
 	if E.db.mMT.portraits.general.classicons and UnitIsPlayer(unit) then
 		local class = select(2, UnitClass(unit))
 		local IconTexture = "Interface\\WorldStateFrame\\Icons-Classes"
-		local coords= CLASS_ICON_TCOORDS[class]
+		local coords = CLASS_ICON_TCOORDS[class]
 		local style = E.db.mMT.portraits.general.classiconstyle
 
 		if mMT.ElvUI_JiberishIcons.loaded and style ~= "BLIZZARD" then
@@ -166,15 +169,20 @@ local function SetPortraits(portrait, unit, masking, mirror)
 		end
 
 		if coords then
-			portrait:SetTexCoord(unpack(coords))
+			local left, right, top, bottom = unpack(coords)
+			portrait:SetTexCoord(mirror and right or left, mirror and left or right, top, bottom)
 			portrait:SetTexture(IconTexture)
 		end
+
+		portrait.mClass = unit
+		portrait.mCoords = coords
 	else
-		if E.db.mMT.portraits.general.classicons then
-			portrait:SetTexCoord(mirror and 1 or 0, mirror and 0 or 1, 0, 1)
-		else
-			mirrorTexture(portrait, mirror)
+		if portrait.mClass then
+			portrait.mClass = nil
+			portrait.mCoords = nil
 		end
+
+		mirrorTexture(portrait, mirror)
 		SetPortraitTexture(portrait, unit, masking)
 	end
 end

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 [Eng] - All changes to this project will be documented in this file. The latest changes are at the top.
 
 
+## [ver. 3.31] - 25.03.2024
+### FIX
+- FIX - Bug with Portrait Class Icons
+
 ## [ver. 3.30] - 25.03.2024
 ### FIX
 - FIX - Dropdown menu Button height, depends now on Font size to prevent overlapping text


### PR DESCRIPTION
## [ver. 3.31] - 25.03.2024
### FIX
- FIX - Bug with Portrait Class Icons

## [ver. 3.30] - 25.03.2024
### FIX
- FIX - Dropdown menu Button height, depends now on Font size to prevent overlapping text
- FIX - misalignment of the non-player Portraits when Classicons is enabled
### Update
- UPDATE - Add Tooltip Anchor settings for Teleports Datatext
- UPDATE - TOC update for Classic and Retail
### NEW
- NEW - Add support for the great Class Icons from Jiberish for Portraits
- NEW - TAG mTargetMarker