### PR TITLE
Update Teleports.lua

### DIFF
--- a/Addon/ElvUI_mMediaTag/modules/datatexts/Teleports.lua
+++ b/Addon/ElvUI_mMediaTag/modules/datatexts/Teleports.lua
@@ -90,6 +90,7 @@ local Teleports = {
 			[30544] = true, --Ultrasafe Transporter: Toshley's Station
 			[18986] = true, --Ultrasafe Transporter: Gadgetzan
 			[18984] = true, --Dimensional Ripper - Everlook
+			[221966] = true, --wormhole-generator-khaz-algar
 		},
 	},
 	items = {


### PR DESCRIPTION
Hey,

I've noticed that the teleporter menu haven't had the Wormhole Generator: Khaz Algar's ID, so added it and tested if all's good.
Seems to be working now while properly showing on the list.

![image](https://github.com/user-attachments/assets/6c749b34-980a-435e-89e4-6a4878ac3b48)
