### PR TITLE
Update ObjectiveTracker.lua

### DIFF
--- a/Addon/ElvUI_mMediaTag/modules/misc/ObjectiveTracker.lua
+++ b/Addon/ElvUI_mMediaTag/modules/misc/ObjectiveTracker.lua
@@ -803,10 +803,12 @@ function module:TrackUntrackQuests()
 		if quest.info then
 			local isOnMap = quest.info.isOnMap
 			local isCampaign = quest.isCampaign
-			if isOnMap or isCampaign then
-				C_QuestLog.AddQuestWatch(id)
-			else
-				C_QuestLog.RemoveQuestWatch(id)
+			if E.db.mMT.objectivetracker.settings.zoneQuests then
+				if isOnMap or isCampaign then
+					C_QuestLog.AddQuestWatch(id)
+				else
+					C_QuestLog.RemoveQuestWatch(id)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Heyo,

While playing, I've noticed that the quests untracked themselves sometimes. After digging a little, I've noticed that it was an issue related to "Show only Quests on map" checkbox in Cosmetic -> Objective Tracker settings, seemed like sometimes the TrackUntrackQuests is ran without checking the selected setting in these functions

init.lua:360-371

```lua
function mMT:ZONE_CHANGED_NEW_AREA()
	mMT.Modules.ObjectiveTracker:TrackUntrackQuests()
	mMT:UpdateText()
end

function mMT:ZONE_CHANGED_INDOORS()
	mMT.Modules.ObjectiveTracker:TrackUntrackQuests()
end

function mMT:ZONE_CHANGED()
	mMT.Modules.ObjectiveTracker:TrackUntrackQuests()
end
``` 

Added the change to ObjectiveTracker.lua itself, though can add it to init.lua instead if you would prefer :-)