### PR TITLE
ver. 3.66

### DIFF
--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag.toc
@@ -1,6 +1,6 @@
 ## Interface: 30403
 ## Author: Blinkii
-## Version: git-dev-3.65
+## Version: 3.66
 ## Title: |CFF3650D5m|r|CFF4148C3M|r|CFF4743B6T -|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: mMediaTag & Tools is a plugin for ElvUI. mMediaTag adds many media files like textures/ fonts/ icons and some tools to ElvUI.
 ## Notes-deDE: mMediaTag & Tools ist ein Plugin für ElvUI. mMediaTag fügt viele Mediendateien wie Texturen/ Schriften/ Symbole und einige Tools zu ElvUI hinzu.

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Cata.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Cata.toc
@@ -1,6 +1,6 @@
 ## Interface: 40401
 ## Author: Blinkii
-## Version: git-dev-3.65
+## Version: 3.66
 ## Title: |CFF3650D5m|r|CFF4148C3M|r|CFF4743B6T -|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon
 ## AddonCompartmentFunc: ElvUI_mMediaTag_OnAddonCompartmentClick

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Mainline.toc
@@ -1,6 +1,6 @@
 ## Interface: 110005
 ## Author: Blinkii
-## Version: git-dev-3.65
+## Version: 3.66
 ## Title: |CFF3650D5m|r|CFF4148C3M|r|CFF4743B6T -|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: ElvUI Plugin from Blinkii | Support: mMediaTag@gmx.de
 ## IconTexture: Interface\AddOns\ElvUI_mMediaTag\media\logo\mmt_icon

--- a/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Vanilla.toc
+++ b/Addon/ElvUI_mMediaTag/ElvUI_mMediaTag_Vanilla.toc
@@ -1,6 +1,6 @@
 ## Interface: 11505
 ## Author: Blinkii
-## Version: git-dev-3.65
+## Version: 3.66
 ## Title: |CFF3650D5m|r|CFF4148C3M|r|CFF4743B6T -|r |CFF6559F1m|r|CFF7A4DEFM|r|CFF8845ECe|r|CFFA037E9d|r|CFFA435E8i|r|CFFB32DE6a|r|CFFBC26E5T|r|CFFCB1EE3a|r|CFFDD14E0g|r |CFFFF006C&|r |CFFFF4C00T|r|CFFFF7300o|r|CFFFF9300o|r|CFFFFA800l|r|CFFFFC900s|r
 ## Notes: mMediaTag & Tools is a plugin for ElvUI. mMediaTag adds many media files like textures/ fonts/ icons and some tools to ElvUI.
 ## Notes-deDE: mMediaTag & Tools ist ein Plugin für ElvUI. mMediaTag fügt viele Mediendateien wie Texturen/ Schriften/ Symbole und einige Tools zu ElvUI hinzu.

--- a/Addon/ElvUI_mMediaTag/core/changelog/3.66.lua
+++ b/Addon/ElvUI_mMediaTag/core/changelog/3.66.lua
@@ -1,7 +1,10 @@
 mMT.Changelog[366]  = {
-	DATE = "Dev not",
-	IMPORTANT = { "there is nothing new here" },
-	NEW = { "there is nothing new here" },
-	UPDATE = { "there is nothing new here" },
-	FIX = { "there is nothing new here" },
+	DATE = "02.12.2024",
+	UPDATE = {
+		"[Portraits]: Diesabled per default Texture color for rare/ elite/ boss Texture."
+	 },
+	FIX = {
+		"[Portraits]: Fix bug with color DB and the new Border colors, when Eltruism r MUI colors are enabled.",
+		"[Portraits]: Party Portraits should update properly in classic."
+	 },
 }

--- a/Addon/ElvUI_mMediaTag/core/settings/defaultSettings.lua
+++ b/Addon/ElvUI_mMediaTag/core/settings/defaultSettings.lua
@@ -746,7 +746,7 @@ P.mMT = {
 			reaction = false,
 			style = "a",
 			trilinear = true,
-			usetexturecolor = true,
+			usetexturecolor = false,
 			deathcolor = false,
 		},
 		zoom = 0,

--- a/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
+++ b/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
@@ -711,9 +711,18 @@ local function PartyUnitOnEvent(self, event, eventUnit)
 		self.eventDesaturationIsSet = true
 	end
 
-	if eventUnit == self.unit or forceUpdateParty[event] then UnitEvent(self, event) end
---#FE9204FF
-	mMT:Print("|CFF0489FEDEBUG|r >>", "|CFF8EFE04PARTY UNITS|r >>", "|CFFC804FEEVENT|r:", event, "|CFFF6FE04UNIT|r:", self.unit, eventUnit, "|CFF0492FESHOULD UPDATE|r:", "|CFFC804FEevent|r > ", forceUpdateParty[event], "|CFFFE9204condition|r >", (eventUnit == self.unit or forceUpdateParty[event]))
+	if event == "GROUP_ROSTER_UPDATE" then
+		-- force party portraits update
+		for i = 1, 5 do
+			module["Party" .. i].unit = module["Party" .. i].parent.unit
+			UnitEvent(module["Party" .. i], event)
+		end
+	elseif eventUnit == self.unit or forceUpdateParty[event] then
+		UnitEvent(self, event)
+	end
+
+	--#FE9204FF
+	--mMT:Print("|CFF0489FEDEBUG|r >>", "|CFF8EFE04PARTY UNITS|r >>", "|CFFC804FEEVENT|r:", event, "|CFFF6FE04UNIT|r:", self.unit, eventUnit, "|CFF0492FESHOULD UPDATE|r:", "|CFFC804FEevent|r > ", forceUpdateParty[event], "|CFFFE9204condition|r >", (eventUnit == self.unit or forceUpdateParty[event]))
 end
 
 local function BossUnitOnEvent(self, event, eventUnit)

--- a/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
+++ b/Addon/ElvUI_mMediaTag/modules/unitframes/portrait.lua
@@ -231,7 +231,7 @@ end
 
 local simpleClassification = {
 	worldboss = "boss",
-	rareelite = "rare",
+	rareelite = "rareelite",
 	elite = "elite",
 	rare = "rare",
 }
@@ -357,19 +357,19 @@ local function UpdatePortrait(portraitFrame, force)
 	-- Portrait Border
 	if E.db.mMT.portraits.shadow.border then
 		texture = portraitFrame.textures.border
-		UpdateTexture(portraitFrame, "border", texture, 2, E.db.mMT.portraits.colors.border.default)
+		UpdateTexture(portraitFrame, "border", texture, 2, colors.border.default)
 	end
 
 	-- Rare/Elite Texture
 	if setting.extraEnable then
 		-- Texture
 		texture = portraitFrame.textures.rare.texture
-		UpdateTexture(portraitFrame, "extra", texture, -6, E.db.mMT.portraits.colors.border.default, not portraitFrame.settings.mirror)
+		UpdateTexture(portraitFrame, "extra", texture, -6, colors.border.default, not portraitFrame.settings.mirror)
 
 		-- Border
 		if E.db.mMT.portraits.shadow.border then
 			texture = portraitFrame.textures.rare.border
-			UpdateTexture(portraitFrame, "extraBorder", texture, -7, E.db.mMT.portraits.colors.border.default, not portraitFrame.settings.mirror)
+			UpdateTexture(portraitFrame, "extraBorder", texture, -7, colors.border.default, not portraitFrame.settings.mirror)
 			portraitFrame.extraBorder:Hide()
 		end
 
@@ -391,7 +391,7 @@ local function UpdatePortrait(portraitFrame, force)
 		-- Border
 		if E.db.mMT.portraits.shadow.border then
 			texture = portraitFrame.textures.corner.border
-			UpdateTexture(portraitFrame, "cornerBorder", texture, 6, E.db.mMT.portraits.colors.border.default)
+			UpdateTexture(portraitFrame, "cornerBorder", texture, 6, colors.border.default)
 			portraitFrame.cornerBorder:Show()
 		end
 
@@ -664,6 +664,7 @@ local function setColors(sourceColors, targetColors)
 	targetColors.rare = sourceColors.rare
 	targetColors.rareelite = sourceColors.rareelite
 	targetColors.elite = sourceColors.elite
+	colors.border = E.db.mMT.portraits.colors.border
 end
 
 local function ConfigureColors()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog - ElvUI_mMediaTag
 [Eng] - All changes to this project will be documented in this file. The latest changes are at the top.
 
-## [ver. 3.66] - xx.xx.xxxx
+## [ver. 3.66] - 02.12.2024
 ### UPDATE
-- UPDATE - [xxx]: xxx
+- UPDATE - [Portraits]: Diesabled per default Texture color for rare/ elite/ boss Texture.
 ### FIX 
-- FIX - [xxx]: xxx
-### NEW
-- New - [xxx]: xxx
+- FIX - [Portraits]: Fix bug with color DB and the new Border colors, when Eltruism r MUI colors are enabled.
+- FIX - [Portraits]: Party Portraits should update properly in classic.
 
 ## [ver. 3.65] - 01.12.2024
 ### UPDATE


### PR DESCRIPTION
## [ver. 3.66] - 02.12.2024
### UPDATE
- UPDATE - [Portraits]: Diesabled per default Texture color for rare/ elite/ boss Texture.
### FIX 
- FIX - [Portraits]: Fix bug with color DB and the new Border colors, when Eltruism r MUI colors are enabled.
- FIX - [Portraits]: Party Portraits should update properly in classic.